### PR TITLE
Fix yard doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ gem install red-palette
 
 To be described later.
 
-See the [documentation](https://rubydoc.info/gems/red-colors) for now.
+See the [documentation](https://rubydoc.info/gems/red-palette) for now.
 
 ## License
 


### PR DESCRIPTION
Hi!

Fixed the link.
I often access the documentation from the README.
That's why I noticed this.

Thank you. 